### PR TITLE
removes need for docker ARG builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ FROM gradle:3.5-jdk7 as builder
 RUN git clone https://github.com/pfstrack/eldamo
 RUN cp -R /home/gradle/eldamo/src/data /home/gradle/eldamo/src/main/webapp/
 
-ARG ELDAMO_VERSION=0.5.0
 # substitute the version into the build file
-RUN sed -ie -E "/version/s/ = '(.+)'/ = '${ELDAMO_VERSION}'/" /home/gradle/eldamo/build.gradle
+USER root
+RUN apt-get update && apt-get install libxml2-utils -y
+USER gradle
+RUN VER=$(xmllint --xpath "string(/*/@version)" /home/gradle/eldamo/src/data/eldamo-data.xml) && \
+    sed -ie -E "/version/s/ = '(.+)'/ = '${VER}'/" /home/gradle/eldamo/build.gradle
 
 WORKDIR /home/gradle/eldamo
 RUN gradle war

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The supplied Dockerfile will create an Eldamo image using multistage Docker buil
 
 ```
 # build an image eldamo:0.7.4
-ELDAMO_VERSION=0.7.4 # set as a variable for reuse in the image tag and in a Docker build arg
-docker build . -t "eldamo:${ELDAMO_VERSION}"--build-arg=ELDAMO_VERSION=${ELDAMO_VERSION}
+ELDAMO_VERSION=0.7.4
+docker build -t "eldamo:${ELDAMO_VERSION}"  .
 
 # run that image (interactively with -it ; detached, substitute -d)
 docker run -it -p 8080:8080 --name eldamo-web eldamo:${ELDAMO_VERSION}
@@ -40,7 +40,7 @@ docker run -it -p 8080:8080 --name eldamo-web eldamo:${ELDAMO_VERSION}
 #### Build with Google Cloud Platform's Cloud Build
 
 One can also build an image on the Google Cloud build service, Cloud Build, using the included cloudbuild.yaml and optionally provide an Eldamo version number as a Cloud Build substitution.
-The default version is 0.5.0.
+The default version is 0.7.4.
 
 ```
 gcloud builds submit --config=cloudbuild.yaml --substitutions=_ELDAMO_VERSION=0.7.4

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/eldamo-build/eldamo:${_ELDAMO_VERSION}', '--build-arg', 'ELDAMO_VERSION=${_ELDAMO_VERSION}', '.' ]
+  args: [ 'build', '-t', 'gcr.io/eldamo-build/eldamo:${_ELDAMO_VERSION}', '.' ]
 images:
 - 'gcr.io/eldamo-build/eldamo:${_ELDAMO_VERSION}'
 substitutions:
-  _ELDAMO_VERSION: 0.5.0
+  _ELDAMO_VERSION: 0.7.4


### PR DESCRIPTION
Removes build args requirement from docker image creation, substituting the ARG ELDAMO_VERSION for an introspection of the eldamo-data.xml file using `xmllint`.

This ensures that the version of the web app is always the same as the data file.

The Cloud Build yaml still requires an image version tag, and that still requires the _ELDAMO_VERSION substitution.